### PR TITLE
Replace document.write with innerHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pisano/react-frame-component",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "React component to wrap your application or component in an iFrame for encapsulation purposes",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -108,9 +108,7 @@ export default class Frame extends Component {
       );
 
       if (initialRender) {
-        doc.open('text/html', 'replace');
-        doc.write(this.props.initialContent);
-        doc.close();
+        doc.documentElement.innerHTML = this.props.initialContent;
         this._setInitialContent = true;
       }
 


### PR DESCRIPTION
Instead of using document.write to inject initialContent we can use innerHTML for the same purpose which does not break <script> injection.
[Reference](https://github.com/ryanseddon/react-frame-component/pull/80/files)

## Testing
Be careful about showing, working properly of iframe widgets
